### PR TITLE
Fix the link to the astropy code of conduct

### DIFF
--- a/codeconduct.md
+++ b/codeconduct.md
@@ -2,8 +2,7 @@
 
 Here follows the code of conduct for work related to FRB Software.
 It is a modified version of
-[the one adopted by the astropy community]
-(https://www.astropy.org/code_of_conduct.html).
+[the one adopted by the astropy community](https://www.astropy.org/code_of_conduct.html).
 
 
 # FRB Software Code of Conduct


### PR DESCRIPTION
Line separation broke the link; removed it