### PR TITLE
Update the 'View on GitHub' banner to link to the FRBs org, not the webpage source

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,3 +1,6 @@
 theme: jekyll-theme-slate
 title : FRB software
 description : The Home of FRB Community Software
+
+github:
+  repository_url: https://github.com/FRBs


### PR DESCRIPTION
Given the goal of the website, it doesn't make much sense for the "View on GitHub" banner to send you to this repo, so this change updates the link to point at the FRBs org instead.