### PR TITLE
Change the homepage title from 'Motivation' to 'Home', project name from "FRB software" to "FRB Software"

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,3 +1,3 @@
 theme: jekyll-theme-slate
-title : FRB software
+title : FRB Software
 description : The Home of FRB Community Software

--- a/index.md
+++ b/index.md
@@ -1,5 +1,6 @@
 ---
 layout: default
+title: Home
 ---
 
 # Motivation


### PR DESCRIPTION
The page seems to be taking on the text from the first header, so the page title for frb.software is "Motivation | FRB software", this forces the name of the homepage to "Home", but can be easily change to anything you guys think might be better.

On a similar vein, it updates the project title from "FRB software" to "FRB Software", so that the home page title is now "Home | FRB Software".
